### PR TITLE
Fix transport namespaces and auto reference asmdefs

### DIFF
--- a/Transports/com.mlapi.contrib.transport.enet/Runtime/EnetTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.enet/Runtime/EnetTransport.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 using Event = ENet.Event;
 using EventType = ENet.EventType;
 
-namespace EnetTransport
+namespace MLAPI.Transports.Enet
 {
     [DefaultExecutionOrder(1000)]
     public class EnetTransport : NetworkTransport

--- a/Transports/com.mlapi.contrib.transport.enet/Runtime/com.mlapi.contrib.transport.enet.asmdef
+++ b/Transports/com.mlapi.contrib.transport.enet/Runtime/com.mlapi.contrib.transport.enet.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "ENET MLAPI Transport",
-    "rootNamespace": "",
+    "rootNamespace": "MLAPI.Transports.Enet",
     "references": [
         "Unity.Multiplayer.MLAPI.Runtime"
     ],
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Transports/com.mlapi.contrib.transport.litenetlib/Runtime/LiteNetLibTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.litenetlib/Runtime/LiteNetLibTransport.cs
@@ -11,7 +11,7 @@ using MLAPI.Logging;
 using UnityEngine;
 using UnityEngine.Assertions;
 
-namespace LiteNetLibTransport
+namespace MLAPI.Transports.LiteNetLib
 {
     public class LiteNetLibTransport : NetworkTransport, INetEventListener
     {

--- a/Transports/com.mlapi.contrib.transport.litenetlib/Runtime/com.mlapi.contrib.transport.litenet.asmdef
+++ b/Transports/com.mlapi.contrib.transport.litenetlib/Runtime/com.mlapi.contrib.transport.litenet.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "LiteNetLib MLAPI Transport",
-    "rootNamespace": "",
+    "rootNamespace": "MLAPI.Transports.LiteNetLib",
     "references": [
         "Unity.Multiplayer.MLAPI.Runtime"
     ],
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Transports/com.mlapi.contrib.transport.ruffles/CHANGELOG.md.meta
+++ b/Transports/com.mlapi.contrib.transport.ruffles/CHANGELOG.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1c5bf7bc01b8d70459b5e5a4106e73bb
+guid: ac1746530893bfd4a949e68f126c1207
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Transports/com.mlapi.contrib.transport.ruffles/LICENSE.meta
+++ b/Transports/com.mlapi.contrib.transport.ruffles/LICENSE.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9a6fb765e42eae348bb948a319b66419
+guid: 53ce0018be7962c4f8c6f767697a5f42
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Transports/com.mlapi.contrib.transport.ruffles/README.md.meta
+++ b/Transports/com.mlapi.contrib.transport.ruffles/README.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c57ec5067a76b5545beb53be11091e99
+guid: e12845b047d367042b95f30017cf00dc
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Transports/com.mlapi.contrib.transport.ruffles/Runtime/Ruffles/AssemblyInfo.cs
+++ b/Transports/com.mlapi.contrib.transport.ruffles/Runtime/Ruffles/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Ruffles.Tests")]

--- a/Transports/com.mlapi.contrib.transport.ruffles/Runtime/Ruffles/Ruffles.csproj
+++ b/Transports/com.mlapi.contrib.transport.ruffles/Runtime/Ruffles/Ruffles.csproj
@@ -1,5 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net35;net471;net45;netstandard2.0;netcoreapp2.0</TargetFrameworks>
-  </PropertyGroup>
-</Project>

--- a/Transports/com.mlapi.contrib.transport.ruffles/Runtime/com.mlapi.contrib.transport.ruffles.asmdef
+++ b/Transports/com.mlapi.contrib.transport.ruffles/Runtime/com.mlapi.contrib.transport.ruffles.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "[name] MLAPI Transport",
+    "name": "Ruffles MLAPI Transport",
     "rootNamespace": "",
     "references": [
         "Unity.Multiplayer.MLAPI.Runtime"
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Transports/com.mlapi.contrib.transport.ruffles/package.json.meta
+++ b/Transports/com.mlapi.contrib.transport.ruffles/package.json.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3bc7bdb9fdc2e7c4493f6667c4e3394d
+guid: 1c91cae63afbd9f4e88cba5e8397e54e
 PackageManifestImporter:
   externalObjects: {}
   userData: 

--- a/Transports/com.mlapi.contrib.transport.steamp2p/Runtime/SteamP2PTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.steamp2p/Runtime/SteamP2PTransport.cs
@@ -17,7 +17,7 @@ using MLAPI.Transports.Tasks;
  * Steamworks.NET: https://steamworks.github.io/
  */
 
-namespace SteamP2PTransport
+namespace MLAPI.Transports.SteamP2P
 {
     public class SteamP2PTransport : NetworkTransport
     {

--- a/Transports/com.mlapi.contrib.transport.steamp2p/Runtime/com.mlapi.contrib.transport.steamp2p.asmdef
+++ b/Transports/com.mlapi.contrib.transport.steamp2p/Runtime/com.mlapi.contrib.transport.steamp2p.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "SteamP2P MLAPI Transport",
-    "rootNamespace": "",
+    "rootNamespace": "MLAPI.Transports.SteamP2P",
     "references": [
         "Unity.Multiplayer.MLAPI.Runtime"
     ],
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Transports/com.mlapi.contrib.transport.template/CHANGELOG.md.meta
+++ b/Transports/com.mlapi.contrib.transport.template/CHANGELOG.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1c5bf7bc01b8d70459b5e5a4106e73bb
+guid: 0a024bb1894e44e4b84f176b0b386f24
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Transports/com.mlapi.contrib.transport.template/LICENSE.meta
+++ b/Transports/com.mlapi.contrib.transport.template/LICENSE.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9a6fb765e42eae348bb948a319b66419
+guid: 56fa6d8e6a036b74eaef27818e3698c4
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Transports/com.mlapi.contrib.transport.template/README.md.meta
+++ b/Transports/com.mlapi.contrib.transport.template/README.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c57ec5067a76b5545beb53be11091e99
+guid: 8ffe30828b308c245b69db7e4a4787d8
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Transports/com.mlapi.contrib.transport.template/Runtime.meta
+++ b/Transports/com.mlapi.contrib.transport.template/Runtime.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bf82db3443f30474d8b29742e12d5760
+guid: d8bfbe123de7f4140b6b2071b1a7cbfa
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Transports/com.mlapi.contrib.transport.template/Runtime/TemplateTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.template/Runtime/TemplateTransport.cs
@@ -1,17 +1,16 @@
 ﻿using System;
-using MLAPI.Transports;
 using MLAPI.Transports.Tasks;
 
 namespace MLAPI.Transports.Template
 {
-    public class TemplateTransport : Transport
+    public class TemplateTransport : NetworkTransport
     {
-        public override void Send(ulong clientId, ArraySegment<byte> data, string channelName)
+        public override void Send(ulong clientId, ArraySegment<byte> data, NetworkChannel channel)
         {
             throw new NotImplementedException();
         }
 
-        public override NetEventType PollEvent(out ulong clientId, out string channelName, out ArraySegment<byte> payload, out float receiveTime)
+        public override NetworkEvent PollEvent(out ulong clientId, out NetworkChannel channel, out ArraySegment<byte> payload, out float receiveTime)
         {
             throw new NotImplementedException();
         }

--- a/Transports/com.mlapi.contrib.transport.template/Runtime/TemplateTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.template/Runtime/TemplateTransport.cs
@@ -2,7 +2,7 @@
 using MLAPI.Transports;
 using MLAPI.Transports.Tasks;
 
-namespace TemplateTransport
+namespace MLAPI.Transports.Template
 {
     public class TemplateTransport : Transport
     {

--- a/Transports/com.mlapi.contrib.transport.template/Runtime/com.mlapi.contrib.transport.template.asmdef
+++ b/Transports/com.mlapi.contrib.transport.template/Runtime/com.mlapi.contrib.transport.template.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "[name] MLAPI Transport",
-    "rootNamespace": "",
+    "rootNamespace": "MLAPI.Transports.[name]",
     "references": [
         "Unity.Multiplayer.MLAPI.Runtime"
     ],
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Transports/com.mlapi.contrib.transport.template/Runtime/com.mlapi.contrib.transport.template.asmdef
+++ b/Transports/com.mlapi.contrib.transport.template/Runtime/com.mlapi.contrib.transport.template.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "[name] MLAPI Transport",
-    "rootNamespace": "MLAPI.Transports.[name]",
+    "rootNamespace": "MLAPI.Transport.[name]",
     "references": [
         "Unity.Multiplayer.MLAPI.Runtime"
     ],

--- a/Transports/com.mlapi.contrib.transport.template/Runtime/com.mlapi.contrib.transport.template.asmdef.meta
+++ b/Transports/com.mlapi.contrib.transport.template/Runtime/com.mlapi.contrib.transport.template.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7917a2cc4edb5ce4b81b4092b91b8b2b
+guid: 2aa43b0c797e0d444a7e82e75d4f2082
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 

--- a/Transports/com.mlapi.contrib.transport.template/package.json.meta
+++ b/Transports/com.mlapi.contrib.transport.template/package.json.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3bc7bdb9fdc2e7c4493f6667c4e3394d
+guid: f719a183491e7c849a3308ea58b10205
 PackageManifestImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
This auto references the transport assemblies so that they can be used in user code. I also took the chance to adjust namespaces to a common format.
Update the transport template to the newest version.