### PR TITLE
fix: Fixes the function used to disconnect remote clients.

### DIFF
--- a/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/PhotonRealtimeTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/PhotonRealtimeTransport.cs
@@ -15,6 +15,8 @@ namespace MLAPI.Transports.PhotonRealtime
     [DefaultExecutionOrder(-1000)]
     public partial class PhotonRealtimeTransport : NetworkTransport, IOnEventCallback
     {
+        private static readonly ArraySegment<byte> s_EmptyArraySegment = new ArraySegment<byte>(Array.Empty<byte>());
+
         [Tooltip("The nickname of the player in the Photon Room. This value is only relevant for other Photon Realtime features. Leaving it empty generates a random name.")]
         [SerializeField]
         private string m_NickName;
@@ -317,7 +319,7 @@ namespace MLAPI.Transports.PhotonRealtime
         {
             if (m_Client.InRoom && this.m_Client.LocalPlayer.IsMasterClient)
             {
-                ArraySegment<byte> payload = default;
+                ArraySegment<byte> payload = s_EmptyArraySegment;
                 RaisePhotonEvent(clientId, true, payload, this.m_KickEventCode);
             }
         }


### PR DESCRIPTION
## Fix for GOMPS-443

Passing the default ArraySegment with underlying array of null to Photon Realtime is not supported.

## To reproduce initial bug:
Start host in editor + 1 build client. Leave playmode as the host while client is still connected. Exception gets thrown.

## Exception we got before was:
```
ArgumentNullException: Value cannot be null.
Parameter name: src
System.Buffer.BlockCopy (System.Array src, System.Int32 srcOffset, System.Array dst, System.Int32 dstOffset, System.Int32 count) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
ExitGames.Client.Photon.StreamBuffer.Write (System.Byte[] buffer, System.Int32 srcOffset, System.Int32 count) (at <7a1610b16458477ca115d303bf8d4590>:0)
ExitGames.Client.Photon.Protocol18.WriteArraySegmentByte (ExitGames.Client.Photon.StreamBuffer stream, System.ArraySegment1[T] seg, System.Boolean writeType) (at <7a1610b16458477ca115d303bf8d4590>:0) ExitGames.Client.Photon.Protocol18.Write (ExitGames.Client.Photon.StreamBuffer stream, System.Object value, ExitGames.Client.Photon.Protocol18+GpType gpType, System.Boolean writeType) (at <7a1610b16458477ca115d303bf8d4590>:0) ExitGames.Client.Photon.Protocol18.Write (ExitGames.Client.Photon.StreamBuffer stream, System.Object value, System.Boolean writeType) (at <7a1610b16458477ca115d303bf8d4590>:0) ExitGames.Client.Photon.Protocol18.WriteParameterTable (ExitGames.Client.Photon.StreamBuffer stream, ExitGames.Client.Photon.ParameterDictionary parameters) (at <7a1610b16458477ca115d303bf8d4590>:0) ExitGames.Client.Photon.Protocol18.SerializeOperationRequest (ExitGames.Client.Photon.StreamBuffer stream, System.Byte operationCode, ExitGames.Client.Photon.ParameterDictionary parameters, System.Boolean setType) (at <7a1610b16458477ca115d303bf8d4590>:0) ExitGames.Client.Photon.PeerBase.SerializeOperationToMessage (System.Byte opCode, ExitGames.Client.Photon.ParameterDictionary parameters, ExitGames.Client.Photon.EgMessageType messageType, System.Boolean encrypt) (at <7a1610b16458477ca115d303bf8d4590>:0) ExitGames.Client.Photon.PhotonPeer.SendOperation (System.Byte operationCode, ExitGames.Client.Photon.ParameterDictionary operationParameters, ExitGames.Client.Photon.SendOptions sendOptions) (at <7a1610b16458477ca115d303bf8d4590>:0) Photon.Realtime.LoadBalancingPeer.OpRaiseEvent (System.Byte eventCode, System.Object customEventContent, Photon.Realtime.RaiseEventOptions raiseEventOptions, ExitGames.Client.Photon.SendOptions sendOptions) (at Library/PackageCache/com.mlapi.contrib.transport.photon-realtime@a918826c5d/Runtime/Photon/PhotonRealtime/Code/LoadBalancingPeer.cs:965) Photon.Realtime.LoadBalancingClient.OpRaiseEvent (System.Byte eventCode, System.Object customEventContent, Photon.Realtime.RaiseEventOptions raiseEventOptions, ExitGames.Client.Photon.SendOptions sendOptions) (at Library/PackageCache/com.mlapi.contrib.transport.photon-realtime@a918826c5d/Runtime/Photon/PhotonRealtime/Code/LoadBalancingClient.cs:2123) MLAPI.Transports.PhotonRealtime.PhotonRealtimeTransport.RaisePhotonEvent (System.UInt64 clientId, System.Boolean isReliable, System.ArraySegment1[T] data, System.Byte eventCode) (at Library/PackageCache/com.mlapi.contrib.transport.photon-realtime@a918826c5d/Runtime/PhotonRealtimeTransport.cs:247)
MLAPI.Transports.PhotonRealtime.PhotonRealtimeTransport.DisconnectRemoteClient (System.UInt64 clientId) (at Library/PackageCache/com.mlapi.contrib.transport.photon-realtime@a918826c5d/Runtime/PhotonRealtimeTransport.cs:321)
MLAPI.NetworkManager.StopServer () (at Library/PackageCache/com.unity.multiplayer.mlapi@3e3aef6aa0/Runtime/Core/NetworkManager.cs:472)
MLAPI.NetworkManager.StopHost () (at Library/PackageCache/com.unity.multiplayer.mlapi@3e3aef6aa0/Runtime/Core/NetworkManager.cs:499)
BossRoom.GameStateBehaviour.OnApplicationQuit () (at Assets/BossRoom/Scripts/Shared/Game/State/GameStateBehaviour.cs:102)
```