### PR TITLE
fix: Fix managed plugin settings for windows platform dlls

### DIFF
--- a/Transports/com.mlapi.contrib.transport.steamp2p/Runtime/Steamworks.NET/Windows-x64/Steamworks.NET.dll.meta
+++ b/Transports/com.mlapi.contrib.transport.steamp2p/Runtime/Steamworks.NET/Windows-x64/Steamworks.NET.dll.meta
@@ -17,9 +17,9 @@ PluginImporter:
       enabled: 0
       settings:
         Exclude Editor: 0
-        Exclude Linux64: 0
-        Exclude OSXUniversal: 0
-        Exclude Win: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
         Exclude Win64: 0
   - first:
       Any: 
@@ -37,21 +37,21 @@ PluginImporter:
   - first:
       Standalone: Linux64
     second:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: None
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: None
   - first:
       Standalone: Win
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: x86
+        CPU: None
   - first:
       Standalone: Win64
     second:

--- a/Transports/com.mlapi.contrib.transport.steamp2p/Runtime/Steamworks.NET/Windows-x86/Steamworks.NET.dll.meta
+++ b/Transports/com.mlapi.contrib.transport.steamp2p/Runtime/Steamworks.NET/Windows-x86/Steamworks.NET.dll.meta
@@ -17,10 +17,10 @@ PluginImporter:
       enabled: 0
       settings:
         Exclude Editor: 0
-        Exclude Linux64: 0
-        Exclude OSXUniversal: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
         Exclude Win: 0
-        Exclude Win64: 0
+        Exclude Win64: 1
   - first:
       Any: 
     second:
@@ -37,13 +37,13 @@ PluginImporter:
   - first:
       Standalone: Linux64
     second:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: None
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: None
   - first:
@@ -55,9 +55,9 @@ PluginImporter:
   - first:
       Standalone: Win64
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: x86_64
+        CPU: None
   - first:
       Windows Store Apps: WindowsStoreApps
     second:


### PR DESCRIPTION
Fixes #42 

Fixes a bug which caused a build with SteamP2PTransport to fail on all platforms.

I tested that building on the following platforms works now:
- windows x86_64
- linux x86_64
- macOs intel 64-bit + Apple silicon