### PR TITLE
Fix: EnetTransport shutdown - explicitly set host to null to prevent error spam. 

### DIFF
--- a/Transports/com.mlapi.contrib.transport.enet/Runtime/EnetTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.enet/Runtime/EnetTransport.cs
@@ -338,6 +338,7 @@ namespace MLAPI.Transports.Enet
             {
                 host.Flush();
                 host.Dispose();
+                host = null;
             }
 
             Library.Deinitialize();


### PR DESCRIPTION
When shutting down the Enet transport, EnetTransport.host.Dispose() is called, which shuts down all internal things. However, the host variable is not explicity set to null. 

This leads to an issue when shutting down, as Update() checks for host?.Flush(), which gets executed due to host not being null. 
Explicity setting host = null fixes this issue, but there might be more elegant ways too.