### PR TITLE
fix: Fix a bug where enet transport does not clear peers on shutdown

### DIFF
--- a/Transports/com.mlapi.contrib.transport.enet/Runtime/EnetTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.enet/Runtime/EnetTransport.cs
@@ -339,6 +339,8 @@ namespace MLAPI.Transports.Enet
                 host.Flush();
                 host.Dispose();
             }
+            
+            connectedEnetPeers.Clear();
 
             Library.Deinitialize();
         }


### PR DESCRIPTION
fixes #45

This is a Enet transport specific issue which had to be fixed in the transport. Peers are now cleared correctly when shutting down allowing for multiple sessions in the same application.