### PR TITLE
Fix for several potential NullReferenceException cases.

### DIFF
--- a/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/Photon/PhotonRealtime/Code/Unity/Editor/Wizard/scripts/WizardWindow.cs
+++ b/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/Photon/PhotonRealtime/Code/Unity/Editor/Wizard/scripts/WizardWindow.cs
@@ -150,7 +150,10 @@ namespace Photon.Realtime.Editor
             this.buttonWidth = 120;
             this.beforeNextCallback = null;
 
-            appIdOrEmail = AppSettingsInstance.AppIdRealtime;
+            if (AppSettingsInstance != null)
+            {
+                appIdOrEmail = AppSettingsInstance.AppIdRealtime;
+            }
             if (string.IsNullOrEmpty(appIdOrEmail))
             {
                 appIdOrEmail = "";

--- a/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/PhotonRealtimeTransport.Matchmaking.cs
+++ b/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/PhotonRealtimeTransport.Matchmaking.cs
@@ -12,7 +12,7 @@ namespace MLAPI.Transports.PhotonRealtime
 		/// Gets the current Master client of the current Room.
 		/// </summary>
 		/// <returns>The master client ID if the client in inside a Room, -1 otherwise.</returns>
-		private int CurrentMasterId => this.m_Client.CurrentRoom != null ? this.m_Client.CurrentRoom.MasterClientId : -1;
+		private int CurrentMasterId => this.m_Client != null && this.m_Client.CurrentRoom != null ? this.m_Client.CurrentRoom.MasterClientId : -1;
 
         /// <summary>Photon ActorNumber of the host/server.</summary>
         private int m_originalRoomMasterClient = -1;

--- a/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/PhotonRealtimeTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/PhotonRealtimeTransport.cs
@@ -329,7 +329,7 @@ namespace MLAPI.Transports.PhotonRealtime
         ///<inheritdoc/>
         public override void DisconnectRemoteClient(ulong clientId)
         {
-            if (m_Client.InRoom && this.m_Client.LocalPlayer.IsMasterClient)
+            if (this.m_Client!= null && m_Client.InRoom && this.m_Client.LocalPlayer.IsMasterClient)
             {
                 ArraySegment<byte> payload = s_EmptyArraySegment;
                 RaisePhotonEvent(clientId, true, payload, this.m_KickEventCode);

--- a/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/PhotonRealtimeTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/PhotonRealtimeTransport.cs
@@ -117,11 +117,11 @@ namespace MLAPI.Transports.PhotonRealtime
         void LateUpdate()
         {
             if (m_Client != null)
-        {
-            FlushAllSendQueues();
+            {
+                FlushAllSendQueues();
 
                 for (int i = 0; i < MAX_DGRAM_PER_FRAME; i++)
-            {
+                {
                     bool anythingLeftToSend = m_Client.LoadBalancingPeer.SendOutgoingCommands();
                     if (!anythingLeftToSend)
                     {
@@ -254,6 +254,13 @@ namespace MLAPI.Transports.PhotonRealtime
         /// <param name="eventCode">Event Code ID</param>
         private void RaisePhotonEvent(ulong clientId, bool isReliable, ArraySegment<byte> data, byte eventCode)
         {
+            if (m_Client == null || !m_Client.InRoom)
+            {
+                // the local client is set to null or it's not in a room. can't send events, so it makes sense to disconnect MLAPI layer.
+                this.InvokeTransportEvent(NetworkEvent.Disconnect);
+                return;
+            }
+
             m_CachedRaiseEventOptions.TargetActors[0] = GetPhotonRealtimeId(clientId);
             var sendOptions = isReliable ? SendOptions.SendReliable : SendOptions.SendUnreliable;
 

--- a/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/PhotonRealtimeTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/PhotonRealtimeTransport.cs
@@ -77,6 +77,11 @@ namespace MLAPI.Transports.PhotonRealtime
         private RaiseEventOptions m_CachedRaiseEventOptions = new RaiseEventOptions() { TargetActors = new int[1] };
 
         /// <summary>
+        /// Limits the number of datagrams sent in a single frame.
+        /// </summary>
+        private const int MAX_DGRAM_PER_FRAME = 4;
+
+        /// <summary>
         /// Gets or sets the room name to create or join.
         /// </summary>
         public string RoomName
@@ -111,11 +116,18 @@ namespace MLAPI.Transports.PhotonRealtime
         /// </summary>
         void LateUpdate()
         {
+            if (m_Client != null)
+        {
             FlushAllSendQueues();
 
-            if (m_Client != null)
+                for (int i = 0; i < MAX_DGRAM_PER_FRAME; i++)
             {
-                do { } while (m_Client.LoadBalancingPeer.SendOutgoingCommands());
+                    bool anythingLeftToSend = m_Client.LoadBalancingPeer.SendOutgoingCommands();
+                    if (!anythingLeftToSend)
+                    {
+                        break;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This should fix issue #69, #70 and #71.
As the m_Client can be set to null, we needed a few more null checks. 

I also added a simple limitation to datagrams being sent in a single frame. This might prevent local networking issues when the send queues have been long.