### PR TITLE
fix data out of bounds

### DIFF
--- a/Transports/com.mlapi.contrib.transport.litenetlib/Runtime/LiteNetLibTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.litenetlib/Runtime/LiteNetLibTransport.cs
@@ -326,13 +326,12 @@ namespace MLAPI.Transports.LiteNetLib
         void INetEventListener.OnNetworkReceive(NetPeer peer, NetPacketReader reader, DeliveryMethod deliveryMethod)
         {
             int size = reader.UserDataSize;
-            byte[] data = m_MessageBuffer;
-
             if (size > m_MessageBuffer.Length)
             {
                 ResizeMessageBuffer(size);
             }
 
+            byte[] data = m_MessageBuffer;
             Buffer.BlockCopy(reader.RawData, reader.UserDataOffset, data, 0, size);
 
             // The last byte sent is used to indicate the channel so don't include it in the payload.


### PR DESCRIPTION
message buffer can change its size if lower than receive length data, but because variable data already assign from message buffer before checking, it will cause out of bounds.

![offset and length out of bounds](https://user-images.githubusercontent.com/8684122/125273168-d79c0e80-e336-11eb-8b27-970a4dd76133.PNG)
