### PR TITLE
Bug in LiteNetLibTransport.cs

### DIFF
--- a/Transports/com.mlapi.contrib.transport.litenetlib/Runtime/LiteNetLibTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.litenetlib/Runtime/LiteNetLibTransport.cs
@@ -326,12 +326,13 @@ namespace MLAPI.Transports.LiteNetLib
         void INetEventListener.OnNetworkReceive(NetPeer peer, NetPacketReader reader, DeliveryMethod deliveryMethod)
         {
             int size = reader.UserDataSize;
-            byte[] data = m_MessageBuffer;
 
             if (size > m_MessageBuffer.Length)
             {
                 ResizeMessageBuffer(size);
             }
+            
+            byte[] data = m_MessageBuffer;
 
             Buffer.BlockCopy(reader.RawData, reader.UserDataOffset, data, 0, size);
 


### PR DESCRIPTION
When `m_MessageBuffer` was resized, `data` was not updated and `Buffer.BlockCopy` threw an Exception, because the destination array was too small.